### PR TITLE
Fix broken compilation in v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,23 @@ or npm:
 npm install --save @react-native-community/segmented-control
 ```
 
-Then you will need to link it to your project. You can follow the [manual linking](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking) instructions for that.
+## Link
+
+- React Native 0.60+
+
+run `cd ios && pod install`
+
+- React Native <= 0.59
+
+run `react-native link @react-native-community/segmented-control`
+
+or you can follow the instructions to [manually link this package](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking).
+
+## Upgrading to React Native _0.60+_
+
+New React Native comes with `autolinking` feature, which automatically links Native Modules in your project. In order to get it to work, make sure you unlink `Segmented Control` first:
+
+`react-native unlink @react-native-community/segmented-control`
 
 ## Migrating from the core `react-native` module
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ or npm:
 npm install --save @react-native-community/segmented-control
 ```
 
+Then you will need to link it to your project. You can follow the [manual linking](https://facebook.github.io/react-native/docs/linking-libraries-ios#manual-linking) instructions for that.
+
 ## Migrating from the core `react-native` module
 
 This module was created when the segmentedControlIos was split out from the core of React Native. To migrate to this module you need to follow the installation instructions above and then change you imports from:

--- a/ios/RNCSegmentedControl.m
+++ b/ios/RNCSegmentedControl.m
@@ -7,9 +7,9 @@
 
 #import "RNCSegmentedControl.h"
 
-#import "RCTConvert.h"
-#import "RCTEventDispatcher.h"
-#import "UIView+React.h"
+#import <React/RCTConvert.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/UIView+React.h>
 
 @implementation RNCSegmentedControl
 

--- a/ios/RNCSegmentedControl.xcodeproj/project.pbxproj
+++ b/ios/RNCSegmentedControl.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		B3E7B58A1CC2AC0600A0062D /* RNCSegmentedControl.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* RNCSegmentedControl.m */; };
+		E1248FAB23D5F9D700C2FB80 /* RNCSegmentedControlManager.m in Sources */ = {isa = PBXBuildFile; fileRef = E1248FAA23D5F9D700C2FB80 /* RNCSegmentedControlManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -23,9 +24,11 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		134814201AA4EA6300B7C361 /* libRNCSegmentedControl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNCSegmentedControl.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		134814201AA4EA6300B7C361 /* libRNCSegmentedControl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libRNCSegmentedControl.a; path = libRNCViewpager.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5881CC2AC0600A0062D /* RNCSegmentedControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCSegmentedControl.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNCSegmentedControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCSegmentedControl.m; sourceTree = "<group>"; };
+		E1248FA923D5F9D700C2FB80 /* RNCSegmentedControlManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCSegmentedControlManager.h; sourceTree = "<group>"; };
+		E1248FAA23D5F9D700C2FB80 /* RNCSegmentedControlManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCSegmentedControlManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -50,6 +53,8 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				E1248FA923D5F9D700C2FB80 /* RNCSegmentedControlManager.h */,
+				E1248FAA23D5F9D700C2FB80 /* RNCSegmentedControlManager.m */,
 				B3E7B5881CC2AC0600A0062D /* RNCSegmentedControl.h */,
 				B3E7B5891CC2AC0600A0062D /* RNCSegmentedControl.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
@@ -95,6 +100,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 58B511D21A9E6C8500147676;
@@ -112,6 +118,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1248FAB23D5F9D700C2FB80 /* RNCSegmentedControlManager.m in Sources */,
 				B3E7B58A1CC2AC0600A0062D /* RNCSegmentedControl.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -204,7 +211,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
-				"$(inherited)",
+					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",

--- a/ios/RNCSegmentedControl.xcodeproj/project.pbxproj
+++ b/ios/RNCSegmentedControl.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		134814201AA4EA6300B7C361 /* libRNCSegmentedControl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; name = libRNCSegmentedControl.a; path = libRNCViewpager.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		134814201AA4EA6300B7C361 /* libRNCSegmentedControl.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNCSegmentedControl.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		B3E7B5881CC2AC0600A0062D /* RNCSegmentedControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCSegmentedControl.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* RNCSegmentedControl.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNCSegmentedControl.m; sourceTree = "<group>"; };
 		E1248FA923D5F9D700C2FB80 /* RNCSegmentedControlManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNCSegmentedControlManager.h; sourceTree = "<group>"; };
@@ -218,7 +218,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = RNCViewpager;
+				PRODUCT_NAME = RNCSegmentedControl;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -234,7 +234,7 @@
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = RNCViewpager;
+				PRODUCT_NAME = RNCSegmentedControl;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;

--- a/ios/RNCSegmentedControlManager.m
+++ b/ios/RNCSegmentedControlManager.m
@@ -7,8 +7,8 @@
 
 #import "RNCSegmentedControlManager.h"
 
-#import "RCTBridge.h"
-#import "RCTConvert.h"
+#import <React/RCTBridge.h>
+#import <React/RCTConvert.h>
 #import "RNCSegmentedControl.h"
 
 @implementation RNCSegmentedControlManager


### PR DESCRIPTION
# Overview
Following the issue in #43 I am adding this PR in order to fix the compilation. Basically I:
 * Added missing files to the XCode project (the `RNCSegmentedControlManager.*` files were not added)
 * Changed the `React` imports in the project from `#import "RCTLibrary.h"` to `#import <React/RCTLibrary.h>`
 * Added a line in the documentation to let users know that they should link this library to their project to make it work. 
**NOTE:** I only added a link to the manually linking instructions, but this should be done in a better way (for instance by doing a `pod install` or something like this). I don't know very  much how installed libraries can be added to the Podfile of the root project when being installed so I did not add that change here, but this would be a nice enhancement to this PR.


# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->
Basically I just tested that by making those changes my app which would not compile before now compiles.
