### PR TITLE
fix: Prevent SegmentedControl from interfering with scrolling in ScrollViews

### DIFF
--- a/ios/RNCSegmentedControl.m
+++ b/ios/RNCSegmentedControl.m
@@ -101,4 +101,10 @@
   return elements;
 }
 
+// Prevents the segmented control from interfering with scroll gestures in ScrollViews.
+// See https://stackoverflow.com/a/58193949
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+  return YES;
+}
+
 @end


### PR DESCRIPTION
# Overview
<!-- Thank you for sending the PR! We appreciate you spending the time to work on these changes. -->
<!-- Help us understand your motivation by explaining why you decided to make this change -->

If a `SegmentedControl` is placed inside a `ScrollView` on iOS, scroll gestures starting inside the `SegmentedControl` will not scroll the `ScrollView`:

https://github.com/user-attachments/assets/7f8c28e3-7455-4ed7-9003-aa91098c40f7

This PR fixes that issue using a solution from https://stackoverflow.com/a/58193949 that involves the [gestureRecognizerShouldBegin](https://developer.apple.com/documentation/uikit/uiview/gesturerecognizershouldbegin(_:)?language=objc) method. The new behavior looks like this:

https://github.com/user-attachments/assets/cc5ee561-6f88-4986-aca1-25c4b4e35301

# Test Plan
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos! Increase test coverage whenever possible. -->

I tried the tests in the above videos (on iOS 18.5 and iOS 26.2). I also did a basic test in iOS 15.2 with the fix applied - iOS 15.2 behaved the same as iOS 18.5.

Additionally, I tried replacing the `ScrollView` with a regular (non-scrolling) `View`. In the non-scrolling `View`, drag gestures on the `SegmentedControl` could freely move vertically without being overridden, which is reasonable behavior.

I also tried testing this with a horizontal `ScrollView` containing just the `SegmentedControl`, as described in the StackOverflow thread. In that case, with this fix applied, swiping on the `SegmentedControl` is disabled entirely, and swiping simply scrolls horizontally. That is reasonable behavior in this situation.

(I did most of my testing before adding comments to the code, but this should not matter.)